### PR TITLE
Update apt lists on dockerfile and remove unused dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ FROM vitr/phantomjs
 
 MAINTAINER vitr http://vit.online
 
-RUN apt-get install -y git python
+RUN  apt-get update -y && \
+     apt-get install -y git python && \
+     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root
 RUN git clone https://github.com/n1k0/casperjs.git
@@ -23,8 +25,13 @@ RUN mkdir /home/casperjs-tests
 
 WORKDIR /home/casperjs-tests
 
+#optional
+RUN  apt-get purge git -y  && \
+     apt-get autoremove -y
+
 # reset from parent image
 ENTRYPOINT []
 
 # run the image as daemon
 CMD echo "casperjs running..." && tail -f /dev/null
+


### PR DESCRIPTION
I figured out that you updated apt lists on parent image, update in this image the apt lists, as in some hosts without that layers could lead to outdated lists and exit on error.
Also removed some installation dependencies that are not used (not much difference size-wise though). 